### PR TITLE
Fix maybe_async_cfg::default

### DIFF
--- a/src/visitor_content.rs
+++ b/src/visitor_content.rs
@@ -9,7 +9,7 @@ use quote::quote;
 use crate::{
     params::MacroParameters,
     visit_ext::{VisitMutExt, Visitor},
-    DEFAULT_CRATE_NAME, MACRO_MAYBE_NAME, MACRO_DEFAULT_NAME,
+    DEFAULT_CRATE_NAME, MACRO_DEFAULT_NAME, MACRO_MAYBE_NAME,
 };
 
 pub struct ContentVisitor {
@@ -38,9 +38,10 @@ impl ContentVisitor {
         node.attrs.retain(|attr| {
             if let Some(prefix) = is_default_attr(attr) {
                 // TODO: This bit may not be right
-                if MacroParameters::from_tokens_in_parens(attr.tokens.clone().into()).is_err() {
-                    return false
-                };
+                match MacroParameters::from_tokens_in_parens(attr.tokens.clone().into()) {
+                    Ok(params) => self.params = params,
+                    _ => return false,
+                }
                 self.params.prefix_set(prefix);
                 false
             } else {


### PR DESCRIPTION
The default `content` blocks no longer seem to be working.

This PR fixes these issues:
- https://github.com/nvksv/maybe-async-cfg/issues/11
- https://github.com/rust-embedded-community/ssd1306/pull/218

I haven't fully committed to reading and understanding the whole proc macro, but this broke [here](https://github.com/nvksv/maybe-async-cfg/commit/9dca16f701fa52e3b05fe7a41787fc1c7f5aac36#diff-c25a6134ae8d0291e8ba9e179934e45b16632a5dc5841041e742d793321f9c64L42) when self.params stopped getting assigned.